### PR TITLE
release: fix release command

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -7,7 +7,7 @@ for lib in ${libs[@]}; do
     lib_name=$(echo "${lib}" | sed -e "s/^dist\///g" | sed -e "s/\//-/g")
 
     echo "Publishing @saltoapis/${lib_name} package"
-    npm publish --registry https://npm.pkg.github.com/ "${lib}/"
+    npm publish --registry https://npm.pkg.github.com/ "${lib}/" --tag "latest"
     echo "Package published"
     echo ""
 done


### PR DESCRIPTION
The latest npm version requires the `tag` to manually be set on pre-release versions. And since we use the commit sha our releases are always treated as pre-relese.

This commit sets the `--tag "latest"` when releasing a new version.